### PR TITLE
feat: more trading infos by parsing more from trading summary endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
 
 [[package]]
 name = "bourso-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bourso_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "bourso-cli"
-version    = "0.3.2"
+version    = "0.4.0"
 edition    = "2021"
 repository = "https://github.com/azerpas/bourso-api"
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,14 @@ Choose the right binary for your OS between:
 
 #### Approve the app (MacOS)
 
-If you then get a `"bourso-cli" cannot be opened because the developer cannot be verified` error, go to `System Preferences > Security & Privacy > General` and click `Open Anyway`
+On MacOS, you may need to allow the app to run.
 
-If the above doesn't help you, make sure the file is executable:
-```sh
-chmod +x bourso-cli
-# if it still says `Permission denied`, try
-chown 777 bourso-cli
+Make sure you move the app to your Applications folder before running it.
+
+Then run the following command in your terminal:
 ```
-
-⚠️ Signing in with a different IP address than the ones you usually use will trigger a security check from Bourso. You'll have to validate the connection from your phone. A [GitHub pull request](https://github.com/azerpas/bourso-api/pull/10) is open to handle this case.
+xattr -r -d com.apple.quarantine /path/to/bourso-cli
+```
 
 #### Verify your installation
 Bourso CLI embeds [SLSA](https://slsa.dev/) standard to verify the integrity of the binary. You can verify the signature of the binary by:
@@ -81,6 +79,8 @@ Save your client ID with this config command:
 ./bourso-cli config
 ```
 The password will be asked each time you run the app to avoid storing it in a file.
+
+⚠️ Signing in with a different IP address than the ones you usually use will trigger a security check from Bourso. You'll have to complete the MFA (Multi-Factor Authentication) process to log in successfully.
 
 ### Get your accounts
 ```

--- a/src/bourso_api/src/client/trade/mod.rs
+++ b/src/bourso_api/src/client/trade/mod.rs
@@ -66,6 +66,9 @@ fn get_trading_summary_url(config: &Config, account: Account) -> Result<String> 
 pub struct TradingSummaryItem {
     /// Either "account" or "positions"
     pub id: String,
+    /// Will be Some if TradingSummaryItem is of id "account"
+    pub account: Option<AccountSummary>,
+    /// Will be Some if TradingSummaryItem is of id "positions"
     pub positions: Option<Vec<PositionSummary>>,
 }
 


### PR DESCRIPTION
Add `account` optional field in `TradingSummaryItem` which contains useful infos like `cash`, `activationDate`, `pricingName`, etc...