### PR TITLE
fix: movement export is now a POST guarded by a CSRF token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
 
 [[package]]
 name = "bourso-cli"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bourso_api",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "bourso_api"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "bourso-cli"
-version    = "0.5.4"
+version    = "0.6.0"
 edition    = "2021"
 repository = "https://github.com/azerpas/bourso-api"
 

--- a/src/bourso_api/Cargo.toml
+++ b/src/bourso_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "bourso_api"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/bourso_api/src/client/transaction.rs
+++ b/src/bourso_api/src/client/transaction.rs
@@ -9,8 +9,6 @@ use regex::Regex;
 use tracing::debug;
 
 lazy_static! {
-    /// CSRF token embedded in the movement-export form.
-    /// Matches: name="movementSearch[_token]" ... value="<token>"
     static ref EXPORT_TOKEN_REGEX: Regex =
         Regex::new(r#"movementSearch\[_token\]"[^>]*?value="(?P<token>[^"]+)""#)
             .expect("Failed to compile export token regex");
@@ -42,11 +40,6 @@ impl BoursoWebClient {
         from_date: &str,
         to_date: &str,
     ) -> Result<Vec<Transaction>> {
-        // Since 2026 the CSV export is a POST guarded by a per-session CSRF
-        // token: GET the export form first, scrape `movementSearch[_token]`,
-        // then POST the search. (The old GET-with-query flow now just 302s to
-        // the HTML form page, which silently yielded zero transactions for
-        // every account.)
         let token = self.get_export_token().await?;
 
         let form: Vec<(&str, &str)> = vec![
@@ -72,8 +65,7 @@ impl BoursoWebClient {
             .send()
             .await?;
 
-        // Follow redirects manually (the client uses Policy::none()); the CSV
-        // download usually arrives after one 302.
+        // Follow redirects manually (the client uses Policy::none())
         let response = if response.status() == 302 {
             let location = response
                 .headers()

--- a/src/bourso_api/src/client/transaction.rs
+++ b/src/bourso_api/src/client/transaction.rs
@@ -3,8 +3,23 @@ use crate::constants::BASE_URL;
 
 use super::BoursoWebClient;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
 use tracing::debug;
+
+lazy_static! {
+    /// CSRF token embedded in the movement-export form.
+    /// Matches: name="movementSearch[_token]" ... value="<token>"
+    static ref EXPORT_TOKEN_REGEX: Regex =
+        Regex::new(r#"movementSearch\[_token\]"[^>]*?value="(?P<token>[^"]+)""#)
+            .expect("Failed to compile export token regex");
+}
+
+/// URL of the page hosting the movement-export form (source of the CSRF token).
+const EXPORT_FORM_URL: &str = "/mon-budget/generate";
+/// Endpoint the export form POSTs to.
+const EXPORT_SUBMIT_PATH: &str = "/budget/exporter-mouvements";
 
 impl BoursoWebClient {
     /// Get the transactions for an account over a date range.
@@ -27,25 +42,38 @@ impl BoursoWebClient {
         from_date: &str,
         to_date: &str,
     ) -> Result<Vec<Transaction>> {
+        // Since 2026 the CSV export is a POST guarded by a per-session CSRF
+        // token: GET the export form first, scrape `movementSearch[_token]`,
+        // then POST the search. (The old GET-with-query flow now just 302s to
+        // the HTML form page, which silently yielded zero transactions for
+        // every account.)
+        let token = self.get_export_token().await?;
+
+        let form: Vec<(&str, &str)> = vec![
+            ("movementSearch[label]", ""),
+            ("movementSearch[selectedAccounts][]", account_id),
+            ("movementSearch[fromDate]", from_date),
+            ("movementSearch[toDate]", to_date),
+            ("movementSearch[format]", "CSV"),
+            ("movementSearch[filtredBy]", "filtredByCategory"),
+            ("movementSearch[category]", ""),
+            ("movementSearch[operationTypes]", ""),
+            ("movementSearch[myBudgetPage]", "1"),
+            ("movementSearch[operationType]", ""),
+            ("movementSearch[_token]", token.as_str()),
+            ("movementSearch[submit]", ""),
+        ];
+
         let response = self
             .client
-            .get(format!("{BASE_URL}/budget/exporter-mouvements"))
-            .query(&[
-                ("movementSearch[selectedAccounts][]", account_id),
-                ("movementSearch[fromDate]", from_date),
-                ("movementSearch[toDate]", to_date),
-                ("movementSearch[format]", "CSV"),
-                ("movementSearch[filteredBy]", "filteredByCategory"),
-                ("movementSearch[catergory]", ""),
-                ("movementSearch[operationTypes]", ""),
-                ("movementSearch[myBudgetPage]", "1"),
-                ("movementSearch[submit]", ""),
-            ])
+            .post(format!("{BASE_URL}{EXPORT_SUBMIT_PATH}"))
             .headers(self.get_headers())
+            .form(&form)
             .send()
             .await?;
 
-        // Follow redirects manually (the client uses Policy::none())
+        // Follow redirects manually (the client uses Policy::none()); the CSV
+        // download usually arrives after one 302.
         let response = if response.status() == 302 {
             let location = response
                 .headers()
@@ -67,24 +95,70 @@ impl BoursoWebClient {
             response
         };
 
-        debug!("Export response status: {}", response.status());
+        let status = response.status();
+        debug!("Export response status: {}", status);
 
         let res = response.bytes().await?;
         let content = String::from_utf8_lossy(&res);
         // Strip BOM if present
         let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
 
-        // An HTML response means no transactions were found for the given period
+        // A non-empty export is CSV. A genuinely EMPTY period, though, bounces
+        // (302) back to the export FORM page (/mon-budget/generate), which is
+        // HTML and still carries the `movementSearch` form — that is the "no
+        // operations" signal and is legitimate (e.g. a savings account with no
+        // recent movement). Any other HTML (a login page, an error page: no
+        // export form) means the session/flow broke — and we must NOT report
+        // zero there, as silently returning an empty list has let callers
+        // overwrite good data with nothing.
         if content.starts_with("<!DOCTYPE") || content.starts_with("<html") {
-            debug!(
-                "No transactions found for account {} from {} to {}",
-                account_id, from_date, to_date
+            let has_export_form = content.contains(r#"name="movementSearch""#)
+                || content.contains("movementSearch[_token]");
+            if has_export_form {
+                debug!(
+                    "No transactions for account {} from {} to {} \
+                     (empty export bounced back to the form page)",
+                    account_id, from_date, to_date
+                );
+                return Ok(Vec::new());
+            }
+            bail!(
+                "Movement export for account {account_id} returned an HTML page \
+                 (status {status}) with no export form — the BoursoBank session \
+                 likely expired or the export flow changed. Refusing to report \
+                 zero transactions."
             );
-            return Ok(Vec::new());
         }
 
         extract_transactions(content)
     }
+
+    /// Fetch the export form page and scrape its `movementSearch[_token]` CSRF
+    /// token, required to POST the movement export.
+    #[cfg(not(tarpaulin_include))]
+    async fn get_export_token(&self) -> Result<String> {
+        let page = self
+            .client
+            .get(format!("{BASE_URL}{EXPORT_FORM_URL}"))
+            .headers(self.get_headers())
+            .send()
+            .await?
+            .text()
+            .await?;
+        extract_export_token(&page)
+    }
+}
+
+/// Extract the `movementSearch[_token]` CSRF token from the export form page.
+fn extract_export_token(page: &str) -> Result<String> {
+    EXPORT_TOKEN_REGEX
+        .captures(page)
+        .and_then(|c| c.name("token"))
+        .map(|m| m.as_str().to_string())
+        .context(
+            "Could not find movementSearch[_token] on the export form page — \
+             the export form layout may have changed or the session expired.",
+        )
 }
 
 /// Parse a French-formatted amount string to f64.
@@ -143,6 +217,24 @@ fn extract_transactions(content: &str) -> Result<Vec<Transaction>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_extract_export_token() {
+        let page = r#"<form name="movementSearch" method="post" action="/budget/exporter-mouvements">
+            <input type="hidden" name="movementSearch[myBudgetPage]" value="1" >
+            <input id="movementSearch__token" type="hidden" name="movementSearch[_token]" value="test-csrf-token-not-a-real-value.1234abcd.5678efgh" >
+            </form>"#;
+        let token = extract_export_token(page).unwrap();
+        assert_eq!(
+            token,
+            "test-csrf-token-not-a-real-value.1234abcd.5678efgh"
+        );
+    }
+
+    #[test]
+    fn test_extract_export_token_missing() {
+        assert!(extract_export_token("<html><body>no form here</body></html>").is_err());
+    }
 
     #[test]
     fn test_parse_amount() {


### PR DESCRIPTION
BoursoBank changed the CSV movement export flow: the old
`GET /budget/exporter-mouvements?movementSearch[...]` now 302-redirects to the
HTML form page `/mon-budget/generate`, so `get_transactions` hits the
"HTML => no transactions" branch and **silently returns an empty list for every
account.**

Reproducible on v0.5.4: `bourso-cli export transactions` returns
`Found 0 transactions` for an account that actually has 77.

### Fix
- GET the export form, scrape `movementSearch[_token]`, then **POST**
  `/budget/exporter-mouvements` with the token and the renamed fields
  (`filtredBy=filtredByCategory`, `category`).
- A genuinely empty period still bounces to the export form (return empty); an
  HTML page **without** the form (expired session / changed flow) now errors
  instead of silently reporting zero, so callers don't overwrite good data with
  nothing.
- Adds unit tests for the token extraction.

Verified against a live account: 0 → 77 transactions; `cargo test` green.