### PR TITLE
fix(export): POST the CSRF-protected export form, and read CSV columns by name

### DIFF
--- a/src/bourso_api/Cargo.lock
+++ b/src/bourso_api/Cargo.lock
@@ -110,7 +110,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -160,16 +160,17 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bourso_api"
-version = "0.4.0"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-stream",
  "chrono",
  "clap",
  "cookie_store 0.21.1",
+ "csv",
  "futures-util",
  "lazy_static",
- "qrcode",
+ "rand",
  "regex",
  "reqwest",
  "reqwest_cookie_store",
@@ -183,18 +184,6 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "bytemuck"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -262,7 +251,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -341,6 +330,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,7 +367,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -459,7 +469,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -497,6 +507,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -801,18 +823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,16 +949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,7 +1025,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1086,6 +1086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,30 +1120,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "qrcode"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
-dependencies = [
- "image",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1239,7 +1265,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1343,22 +1369,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1455,6 +1491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,7 +1518,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1677,7 +1724,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1782,6 +1829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,7 +1881,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
  "wasm-bindgen-shared",
 ]
 
@@ -2115,6 +2171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,8 +2201,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2160,7 +2242,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
  "synstructure",
 ]
 
@@ -2200,5 +2282,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]

--- a/src/bourso_api/src/client/transaction.rs
+++ b/src/bourso_api/src/client/transaction.rs
@@ -4,6 +4,7 @@ use crate::constants::BASE_URL;
 use super::BoursoWebClient;
 
 use anyhow::{Context, Result};
+use regex::Regex;
 use tracing::debug;
 
 impl BoursoWebClient {
@@ -27,19 +28,38 @@ impl BoursoWebClient {
         from_date: &str,
         to_date: &str,
     ) -> Result<Vec<Transaction>> {
+        // The export is a CSRF-protected form POST: first fetch the form page to
+        // read its per-session `_token`, then POST the export request.
+        let form_page = self
+            .client
+            .get(format!("{BASE_URL}/mon-budget/generate"))
+            .headers(self.get_headers())
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        let token = Regex::new(r#"movementSearch\[_token\][^>]*?value="(?P<token>[^"]*)""#)
+            .expect("valid regex")
+            .captures(&form_page)
+            .and_then(|c| c.name("token"))
+            .context("Could not find export form CSRF token")?
+            .as_str()
+            .to_string();
+
         let response = self
             .client
-            .get(format!("{BASE_URL}/budget/exporter-mouvements"))
-            .query(&[
+            .post(format!("{BASE_URL}/budget/exporter-mouvements"))
+            .form(&[
                 ("movementSearch[selectedAccounts][]", account_id),
                 ("movementSearch[fromDate]", from_date),
                 ("movementSearch[toDate]", to_date),
                 ("movementSearch[format]", "CSV"),
-                ("movementSearch[filteredBy]", "filteredByCategory"),
-                ("movementSearch[catergory]", ""),
+                ("movementSearch[filtredBy]", "filtredByCategory"),
+                ("movementSearch[category]", ""),
                 ("movementSearch[operationTypes]", ""),
                 ("movementSearch[myBudgetPage]", "1"),
-                ("movementSearch[submit]", ""),
+                ("movementSearch[_token]", &token),
             ])
             .headers(self.get_headers())
             .send()

--- a/src/bourso_api/src/client/transaction.rs
+++ b/src/bourso_api/src/client/transaction.rs
@@ -3,7 +3,7 @@ use crate::constants::BASE_URL;
 
 use super::BoursoWebClient;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use regex::Regex;
 use tracing::debug;
 
@@ -94,33 +94,26 @@ impl BoursoWebClient {
         // Strip BOM if present
         let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
 
-        // An HTML response means no transactions were found for the given period
-        if content.starts_with("<!DOCTYPE") || content.starts_with("<html") {
-            debug!(
-                "No transactions found for account {} from {} to {}",
-                account_id, from_date, to_date
-            );
-            return Ok(Vec::new());
-        }
-
         extract_transactions(content)
     }
 }
+
+/// Rendered in place of a CSV body when the export filters match no movement.
+const NO_MOVEMENTS_MARKER: &str = "Aucune opération ne correspond";
 
 /// Parse a French-formatted amount string to f64.
 ///
 /// Handles thousands separators (spaces and non-breaking spaces) and
 /// comma decimal separators as used in BoursoBank CSV exports.
-fn parse_amount(s: &str) -> f64 {
+fn parse_amount(s: &str) -> Result<f64> {
     let cleaned = s
         .trim()
         .replace('\u{a0}', "")
         .replace(' ', "")
         .replace(',', ".");
-    if cleaned.is_empty() {
-        return 0.0;
-    }
-    cleaned.parse::<f64>().unwrap_or(0.0)
+    cleaned
+        .parse::<f64>()
+        .with_context(|| format!("Unparseable amount {s:?} in export"))
 }
 
 /// Extract transactions from a BoursoBank CSV export string.
@@ -133,28 +126,77 @@ fn parse_amount(s: &str) -> f64 {
 ///
 /// The transactions list as a vector of `Transaction`.
 fn extract_transactions(content: &str) -> Result<Vec<Transaction>> {
+    // Getting a web page where CSV was requested means either "nothing matched the
+    // filters" or that we were bounced (expired session, changed export flow). Only
+    // the first is an empty result; treating both as one hid a broken export before.
+    if content.starts_with("<!DOCTYPE") || content.starts_with("<html") {
+        if content.contains(NO_MOVEMENTS_MARKER) {
+            return Ok(Vec::new());
+        }
+        bail!(
+            "Export returned an HTML page instead of CSV, and it does not say the filters matched nothing; the session has most likely expired"
+        );
+    }
+
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(b';')
         .has_headers(true)
         .flexible(true)
         .from_reader(content.as_bytes());
 
+    // Column positions shift between exports: BoursoBank only emits `tags` when some
+    // transaction in the range is tagged, which slides every later column right by one.
+    // Reading by position silently mis-parsed amounts, so fields are resolved by name.
+    let headers = reader
+        .headers()
+        .context("Export has no CSV header")?
+        .clone();
+    let column = |name: &str| headers.iter().position(|header| header.trim() == name);
+
+    let date_op = column("dateOp").context("Export has no `dateOp` column")?;
+    let label = column("label").context("Export has no `label` column")?;
+    let amount = column("amount").context("Export has no `amount` column")?;
+    // The remaining columns are presentational and genuinely absent from some exports.
+    let date_val = column("dateVal");
+    let category = column("category");
+    let category_parent = column("categoryParent");
+    // Renamed across export versions; both spellings carry BoursoBank's supplier guess.
+    let supplier_found = column("suggestedLabel").or_else(|| column("supplierFound"));
+    let comment = column("comment");
+    let account_num = column("accountNum");
+    let account_label = column("accountLabel");
+    let account_balance = column("accountbalance");
+
     reader
         .records()
         .map(|result| {
             let record = result.context("Failed to parse CSV record")?;
+            let field = |index: Option<usize>| {
+                index
+                    .and_then(|index| record.get(index))
+                    .unwrap_or_default()
+                    .to_string()
+            };
             Ok(Transaction {
-                date_op: record.get(0).unwrap_or("").to_string(),
-                date_val: record.get(1).unwrap_or("").to_string(),
-                label: record.get(2).unwrap_or("").to_string(),
-                category: record.get(3).unwrap_or("").to_string(),
-                category_parent: record.get(4).unwrap_or("").to_string(),
-                supplier_found: record.get(5).unwrap_or("").to_string(),
-                amount: parse_amount(record.get(6).unwrap_or("")),
-                comment: record.get(7).unwrap_or("").to_string(),
-                account_num: record.get(8).unwrap_or("").to_string(),
-                account_label: record.get(9).unwrap_or("").to_string(),
-                account_balance: parse_amount(record.get(10).unwrap_or("")),
+                date_op: field(Some(date_op)),
+                date_val: field(date_val),
+                label: field(Some(label)),
+                category: field(category),
+                category_parent: field(category_parent),
+                supplier_found: field(supplier_found),
+                amount: parse_amount(
+                    record
+                        .get(amount)
+                        .context("CSV record is missing its amount field")?,
+                )?,
+                comment: field(comment),
+                account_num: field(account_num),
+                account_label: field(account_label),
+                account_balance: match account_balance.and_then(|index| record.get(index)) {
+                    // Absent on the running-balance-less exports; 0.0 is not a real balance.
+                    None | Some("") => 0.0,
+                    Some(balance) => parse_amount(balance)?,
+                },
             })
         })
         .collect()
@@ -166,43 +208,80 @@ mod tests {
 
     #[test]
     fn test_parse_amount() {
-        assert_eq!(parse_amount("-568,13"), -568.13);
-        assert_eq!(parse_amount("1 718,70"), 1718.70);
-        assert_eq!(parse_amount("-8,99"), -8.99);
-        assert_eq!(parse_amount("37.29"), 37.29);
-        assert_eq!(parse_amount(""), 0.0);
-        assert_eq!(parse_amount("  "), 0.0);
+        assert_eq!(parse_amount("-568,13").unwrap(), -568.13);
+        assert_eq!(parse_amount("1 718,70").unwrap(), 1718.70);
+        assert_eq!(parse_amount("-8,99").unwrap(), -8.99);
+        assert_eq!(parse_amount("37.29").unwrap(), 37.29);
+        assert!(parse_amount("").is_err());
+        assert!(parse_amount("n/a").is_err());
     }
 
     #[test]
     fn test_extract_transactions() {
         let transactions = extract_transactions(TRANSACTIONS_CSV).unwrap();
         assert_eq!(transactions.len(), 3);
-        assert_eq!(transactions[0].date_op, "2026-02-09");
-        assert_eq!(transactions[0].label, "VIR SEPA Loyer Villard");
-        assert_eq!(transactions[0].amount, -568.13);
-        assert_eq!(transactions[0].account_balance, 37.29);
-        assert_eq!(transactions[0].category, "Virements émis");
-        assert_eq!(transactions[1].date_op, "2026-02-06");
-        assert_eq!(transactions[1].label, "CARTE 05/02/26 AMZN Mktp FR*308J CB*7686");
-        assert_eq!(transactions[1].amount, -8.99);
-        assert_eq!(transactions[2].label, "VIR SEPA FRANCE TRAVAIL");
-        assert_eq!(transactions[2].amount, 1718.70);
-        assert_eq!(transactions[2].account_balance, 629.41);
+        assert_eq!(transactions[0].date_op, "2026-07-24");
+        assert_eq!(transactions[0].label, "VIR INST REMBOURSEMENT");
+        assert_eq!(transactions[0].amount, 21.81);
+        assert_eq!(transactions[0].account_balance, 0.05);
+        assert_eq!(transactions[0].category, "Virements reçus");
+        assert_eq!(transactions[1].supplier_found, "Cloudflare");
+        assert_eq!(transactions[1].amount, -3.94);
+        assert_eq!(transactions[2].supplier_found, "Lidl");
+        assert_eq!(transactions[2].amount, -13.69);
+    }
+
+    /// BoursoBank emits `tags` only when a transaction in the range carries one,
+    /// sliding every later column right. Both shapes must parse identically.
+    #[test]
+    fn test_extract_transactions_ignores_column_shift() {
+        let without_tags = extract_transactions(TRANSACTIONS_CSV).unwrap();
+        let with_tags = extract_transactions(TRANSACTIONS_CSV_WITH_TAGS).unwrap();
+
+        let amounts = |txs: &[Transaction]| txs.iter().map(|tx| tx.amount).collect::<Vec<_>>();
+        let suppliers = |txs: &[Transaction]| {
+            txs.iter()
+                .map(|tx| tx.supplier_found.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(amounts(&without_tags), amounts(&with_tags));
+        assert_eq!(suppliers(&without_tags), suppliers(&with_tags));
     }
 
     #[test]
-    fn test_extract_transactions_empty_html() {
-        let html = "<!DOCTYPE html><html><body>Error</body></html>";
-        // HTML content should not be passed to extract_transactions
-        // (handled by get_transactions), but let's verify it fails gracefully
-        let result = extract_transactions(html);
-        assert!(result.is_err() || result.unwrap().is_empty());
+    fn test_extract_transactions_rejects_missing_amount_column() {
+        let csv = "dateOp;label;comment\n2026-07-24;VIR;\n";
+        assert!(extract_transactions(csv).is_err());
     }
 
-    pub const TRANSACTIONS_CSV: &str = r#"dateOp;dateVal;label;category;categoryParent;supplierFound;amount;comment;accountNum;accountLabel;accountbalance
-2026-02-09;2026-02-09;"VIR SEPA Loyer Villard";"Virements émis";"Virements émis";"virement loyer villard";-568,13;;00040613484;BoursoBank;37.29
-2026-02-06;2026-02-06;"CARTE 05/02/26 AMZN Mktp FR*308J CB*7686";"Livres, CD/DVD, bijoux, jouets…";"Vie quotidienne";amazon;-8,99;;00040613484;BoursoBank;605.42
-2026-02-03;2026-02-03;"VIR SEPA FRANCE TRAVAIL";"Virements reçus";"Virements reçus";"virement france travail";1 718,70;;00040613484;BoursoBank;629.41
+    /// BoursoBank answers an empty range with the search page, not an empty CSV.
+    #[test]
+    fn test_extract_transactions_empty_range_is_not_an_error() {
+        let html = format!(
+            "<!DOCTYPE html><html><body>{}  vos filtres de recherche.</body></html>",
+            NO_MOVEMENTS_MARKER
+        );
+        assert!(extract_transactions(&html).unwrap().is_empty());
+    }
+
+    /// Any other page (an expired session bouncing us to login) must not read as "no
+    /// transactions" — that camouflage is what hid a broken export for so long.
+    #[test]
+    fn test_extract_transactions_rejects_unexpected_html() {
+        let html = "<!DOCTYPE html><html><body>Identifiez-vous</body></html>";
+        assert!(extract_transactions(html).is_err());
+    }
+
+    pub const TRANSACTIONS_CSV: &str = r#"dateOp;dateVal;label;suggestedLabel;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance;mark
+2026-07-24;2026-07-24;"VIR INST REMBOURSEMENT";"Vir Inst Remboursement";"Virements reçus";"Virements reçus";21,81;;00012345678;BoursoBank;0.05;Non
+2026-07-22;2026-07-22;"CARTE 20/07/26 CLOUDFLARE CB*1234";Cloudflare;"Non catégorisé";"Non catégorisé";-3,94;;00012345678;BoursoBank;-21.76;Non
+2026-07-22;2026-07-22;"CARTE 21/07/26 LIDL 1234 CB*1234";Lidl;Alimentation;"Vie quotidienne";-13,69;;00012345678;BoursoBank;-21.76;Non
+"#;
+
+    /// Same rows, but with the `tags` column BoursoBank inserts at index 3.
+    pub const TRANSACTIONS_CSV_WITH_TAGS: &str = r#"dateOp;dateVal;label;tags;suggestedLabel;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance;mark
+2026-07-24;2026-07-24;"VIR INST REMBOURSEMENT";;"Vir Inst Remboursement";"Virements reçus";"Virements reçus";21,81;;00012345678;BoursoBank;0.05;Non
+2026-07-22;2026-07-22;"CARTE 20/07/26 CLOUDFLARE CB*1234";vacances;Cloudflare;"Non catégorisé";"Non catégorisé";-3,94;;00012345678;BoursoBank;-21.76;Non
+2026-07-22;2026-07-22;"CARTE 21/07/26 LIDL 1234 CB*1234";;Lidl;Alimentation;"Vie quotidienne";-13,69;;00012345678;BoursoBank;-21.76;Non
 "#;
 }


### PR DESCRIPTION
`bourso export transactions` currently returns nothing, or returns wrong numbers. Two independent causes, one commit each.

## 1. The export endpoint needs a CSRF-protected POST

`GET /budget/exporter-mouvements` no longer serves CSV. BoursoBank moved the export behind a form carrying a per-session `_token`, so the request has to be a POST that echoes it back. The token is scraped from `/mon-budget/generate`.

Without it every export lands on an HTML page, which the old code read as "no transactions in this range" — so it failed silently.

Three field names were wrong too: it's `filtredBy` and `filtredByCategory` (their typo, not ours), and `category`, not `catergory`.

## 2. CSV columns have to be resolved by header name

BoursoBank only emits the `tags` column when something in the range is tagged, and newer exports call the supplier guess `suggestedLabel` instead of `supplierFound`. Either one shifts every later column by one position.

Reading by fixed index therefore put the *category* string into `amount` and the *category parent* into `accountBalance`, depending on the account and date range. Amounts came out wrong with nothing signalling a failure.

Columns are now looked up by header name. `dateOp`, `label` and `amount` are required; everything else is optional and defaults to empty.

Two more instances of the same silent-failure pattern, fixed alongside:

- `parse_amount` returned `0.0` for anything it couldn't parse. It returns a `Result` now.
- Any HTML response was treated as an empty range, including an expired session. Only the page that literally contains *"Aucune opération ne correspond"* counts as empty; anything else is an error.

## Tests

14 passing, up from 11. New cases: column-shift equivalence (the same rows with and without a `tags` column must parse identically), a CSV missing the `amount` column, the genuinely-empty-range page, and the expired-session page.

The existing fixture carried a real account number and card suffix — replaced with synthetic values.
