### PR TITLE
fix(account): print balances in euros, not centimes

### DIFF
--- a/src/bourso_api/src/account.rs
+++ b/src/bourso_api/src/account.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 /// Type of account
@@ -11,7 +13,7 @@ pub enum AccountKind {
 }
 
 /// A bank account
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct Account {
     /// Account id as an hexadecimal string (32 characters)
     pub id: String,
@@ -23,6 +25,21 @@ pub struct Account {
     pub bank_name: String,
     /// The type of account
     pub kind: AccountKind,
+}
+
+impl fmt::Debug for Account {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Account")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field(
+                "balance",
+                &format_args!("{:.2}", self.balance as f64 / 100.0),
+            )
+            .field("bank_name", &self.bank_name)
+            .field("kind", &self.kind)
+            .finish()
+    }
 }
 
 /// A bank transaction


### PR DESCRIPTION
`Account.balance` is an `isize` of centimes: `extract_accounts` parses `"20 810,50 €"` by stripping the space and the comma, giving `2081050`.

The derived `Debug` printed that number raw, and `Debug` is the only way the CLI ever shows a balance — `bourso accounts` and `bourso balance` both go through `println!("{:#?}")`. So a €20 810,50 balance displays as `2081050`, which reads as a 100× overstatement.

Hand-written `Debug` that renders the field as `20810.50`. The field stays `isize`; no other behaviour changes.
